### PR TITLE
Better back-end validation

### DIFF
--- a/app/models/valuation.rb
+++ b/app/models/valuation.rb
@@ -15,6 +15,10 @@ class Valuation < ApplicationRecord
 
   after_commit :sync_account
 
+  before_save do
+    self.value = BigDecimal(self.value)
+  end
+
   scope :in_period, ->(period) { period.date_range.nil? ? all : where(date: period.date_range) }
 
   def self.to_series(account, period = Period.all)


### PR DESCRIPTION
If you just type "0", it saves it as an integer, which then breaks a bunch of stuff downstream which is expecting a BigDecimal. 

I think there are much better ways to accomplish this intended goal so please critique!